### PR TITLE
AdfsFarmNode: Fix AdfsSyncProperties when using a Remote SQL Database

### DIFF
--- a/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.psm1
+++ b/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.psm1
@@ -185,16 +185,23 @@ function Get-TargetResource
         }
 
         # If using WID, object returned is of type 'SyncProperties' with PrimaryComputerName/Port properties
-        if ((Get-ObjectType -Object $adfsSyncProperties) -eq $script:SyncPropertiesTypeName)
+        $adfsSyncPropertiesObjectTypeName = Get-ObjectType -Object $adfsSyncProperties
+        if ($adfsSyncPropertiesObjectTypeName -eq $script:SyncPropertiesTypeName)
         {
             $primaryComputerName = $adfsSyncProperties.PrimaryComputerName
             $primaryComputerPort = $adfsSyncProperties.PrimaryComputerPort
         }
         # If using SQL, object returned is of type 'SyncPropertiesBase', with no PrimaryComputerName/Port properties
-        else
+        elseif ($adfsSyncPropertiesObjectTypeName -eq $script:syncPropertiesBaseTypeName)
         {
             $primaryComputerName = $null
             $primaryComputerPort = $null
+        }
+        else
+        {
+            $errorMessage = ($script:localizedData.UnknownAdfsSyncPropertiesObjectTypeError -f
+                $adfsSyncPropertiesObjectTypeName)
+            New-InvalidOperationException -Message $errorMessage
         }
 
         # Get ADFS SQL Connection String

--- a/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.psm1
+++ b/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.psm1
@@ -216,8 +216,8 @@ function Get-TargetResource
             CertificateThumbprint         = $certificateThumbprint
             GroupServiceAccountIdentifier = $groupServiceAccountIdentifier
             ServiceAccountCredential      = $serviceAccountCredential
-            PrimaryComputerName           = $adfsSyncProperties.PrimaryComputerName
-            PrimaryComputerPort           = $adfsSyncProperties.PrimaryComputerPort
+            PrimaryComputerName           = $primaryComputerName
+            PrimaryComputerPort           = $primaryComputerPort
             SQLConnectionString           = $sqlConnectionString
             Ensure                        = 'Present'
         }

--- a/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.psm1
+++ b/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.psm1
@@ -79,8 +79,8 @@ Import-Module -Name (Join-Path -Path $script:localizationModulePath -ChildPath "
 $script:localizedData = Get-LocalizedData -ResourceName $script:dscResourceName
 
 $script:adfsServiceName = 'adfssrv'
-$script:AdfsAddFarmNodeFileNotFoundErrorId = `
-    'System.IO.FileNotFoundException,Microsoft.IdentityServer.Deployment.Commands.JoinFarmCommand'
+$script:syncPropertiesTypeName = 'Microsoft.IdentityServer.Management.Resources.SyncProperties'
+$script:syncPropertiesBaseTypeName = 'Microsoft.IdentityServer.Management.Resources.SyncPropertiesBase'
 
 function Get-TargetResource
 {
@@ -186,7 +186,7 @@ function Get-TargetResource
         }
 
         # If using WID, object returned is of type 'SyncProperties' with PrimaryComputerName/Port properties
-        if ($adfsSyncProperties -is [Microsoft.IdentityServer.Management.Resources.SyncProperties])
+        if ((Get-ObjectType -Object $adfsSyncProperties) -eq $script:SyncPropertiesTypeName)
         {
             $primaryComputerName = $adfsSyncProperties.PrimaryComputerName
             $primaryComputerPort = $adfsSyncProperties.PrimaryComputerPort

--- a/DSCResources/MSFT_AdfsFarmNode/en-US/MSFT_AdfsFarmNode.strings.psd1
+++ b/DSCResources/MSFT_AdfsFarmNode/en-US/MSFT_AdfsFarmNode.strings.psd1
@@ -20,4 +20,5 @@ ConvertFrom-StringData @'
     GettingAdfsServiceError                  = Error getting the ADFS service details for '{0}'. (NDE0017)
     GettingAdfsSecurityTokenServiceError     = Error getting the ADFS Security Token Service details for '{0}'. (NDE0018)
     GettingAdfsSyncPropertiesError           = Error getting the ADFS sync properties for '{0}'. (NDE0019)
+    UnknownAdfsSyncPropertiesObjectTypeError = Error unknown AdfsSyncProperties object type '{0}. (NDE0020)
 '@

--- a/Modules/AdfsDsc.Common/AdfsDsc.Common.psm1
+++ b/Modules/AdfsDsc.Common/AdfsDsc.Common.psm1
@@ -1036,6 +1036,25 @@ function Get-AdfsConfigurationStatus
     $ReturnValue
 }
 
+function Get-ObjectType
+{
+    <#
+        .SYNOPSIS
+            Returns the type name of the input object
+    #>
+
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [System.Management.Automation.PSObject]
+        $Object
+    )
+
+    $Object.GetType().FullName
+}
+
 $script:localizedData = Get-LocalizedData -ResourceName 'AdfsDsc.Common' -ScriptRoot $PSScriptRoot
 $script:adfsServiceName = 'adfssrv'
 
@@ -1056,4 +1075,5 @@ Export-ModuleMember -Function @(
     'Assert-Command'
     'Assert-GroupServiceAccount'
     'Get-AdfsConfigurationStatus'
+    'Get-ObjectType'
 )

--- a/Tests/Unit/AdfsDsc.Common.Tests.ps1
+++ b/Tests/Unit/AdfsDsc.Common.Tests.ps1
@@ -1558,4 +1558,14 @@ InModuleScope 'AdfsDsc.Common' {
             }
         }
     }
+
+    Describe 'AdfsDsc.Common\Get-ObjectType' {
+        BeforeAll {
+            $mockStringObject = [System.String]'StringObject'
+        }
+
+        It 'Should return the correct result' {
+            Get-ObjectType -Object $mockStringObject | Should -Be 'System.String'
+        }
+    }
 }

--- a/Tests/Unit/MSFT_AdfsFarmNode.tests.ps1
+++ b/Tests/Unit/MSFT_AdfsFarmNode.tests.ps1
@@ -288,6 +288,19 @@ try
                                 $mockWidResource.FederationServiceName)
                         }
                     }
+
+                    Context 'When Get-AdfsSyncProperties returns an unexpected type' {
+                        BeforeAll {
+                            $mockUnexpectedType = 'UnexpectedType'
+                            Mock Get-ObjectType -MockWith { $mockUnexpectedType }
+                        }
+
+                        It 'Should throw the correct exception' {
+                            { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
+                                $script:localizedData.UnknownAdfsSyncPropertiesObjectTypeError -f
+                                $mockUnexpectedType)
+                        }
+                    }
                 }
 
                 Context "When the configured database is SQL" {

--- a/Tests/Unit/MSFT_AdfsFarmNode.tests.ps1
+++ b/Tests/Unit/MSFT_AdfsFarmNode.tests.ps1
@@ -43,29 +43,42 @@ try
 
         $sqlConnectionString = 'TBC'
 
-        $mockResource = @{
-            FederationServiceName         = 'sts.contoso.com'
-            CertificateThumbprint         = '6F7E9F5543505B943FEEA49E651EDDD8D9D45011'
-            PrimaryComputerName           = 'adfs01'
-            PrimaryComputerPort           = 80
-            SQLConnectionString           = $SQLConnectionString
-            Ensure                        = 'Present'
+        $mockWidResource = @{
+            FederationServiceName = 'sts.contoso.com'
+            CertificateThumbprint = '6F7E9F5543505B943FEEA49E651EDDD8D9D45011'
+            PrimaryComputerName   = 'adfs01'
+            PrimaryComputerPort   = 80
+            SQLConnectionString   = $SQLConnectionString
+            Ensure                = 'Present'
         }
 
-        $mockGsaResource = $mockResource.Clone()
-        $mockGsaResource += @{
+        $mockSqlResource = @{
+            FederationServiceName = 'sts.contoso.com'
+            CertificateThumbprint = '6F7E9F5543505B943FEEA49E651EDDD8D9D45011'
+            SQLConnectionString   = $SQLConnectionString
+            Ensure                = 'Present'
+        }
+
+        $mockGsaWidResource = $mockWidResource.Clone()
+        $mockGsaWidResource += @{
             GroupServiceAccountIdentifier = 'CONTOSO\AdfsGmsa'
             ServiceAccountCredential      = $null
         }
 
-        $mockSaResource = $mockResource.Clone()
+        $mockGsaSqlResource = $mockSqlResource.Clone()
+        $mockGsaSqlResource += @{
+            GroupServiceAccountIdentifier = 'CONTOSO\AdfsGmsa'
+            ServiceAccountCredential      = $null
+        }
+
+        $mockSaResource = $mockWidResource.Clone()
         $mockSaResource += @{
             GroupServiceAccountIdentifier = $null
             ServiceAccountCredential      = $mockMSFTCredential
         }
 
         $mockAbsentResource = @{
-            FederationServiceName         = $mockResource.FederationServiceName
+            FederationServiceName         = $mockWidResource.FederationServiceName
             CertificateThumbprint         = $null
             GroupServiceAccountIdentifier = $null
             ServiceAccountCredential      = $null
@@ -75,25 +88,25 @@ try
             Ensure                        = 'Absent'
         }
 
-        $mockGetTargetResourceResult = @{
-            FederationServiceName         = $mockGsaResource.FederationServiceName
-            CertificateThumbprint         = $mockGsaResource.CertificateThumbprint
-            GroupServiceAccountIdentifier = $mockGsaResource.GroupServiceAccountIdentifier
-            ServiceAccountCredential      = $mockGsaResource.ServiceAccountCredential
-            PrimaryComputerName           = $mockGsaResource.PrimaryComputerName
-            PrimaryComputerPort           = $mockGsaResource.PrimaryComputerPort
-            SQLConnectionString           = $mockGsaResource.SQLConnectionString
+        $mockGetTargetGsaWidResourceResult = @{
+            FederationServiceName         = $mockGsaWidResource.FederationServiceName
+            CertificateThumbprint         = $mockGsaWidResource.CertificateThumbprint
+            GroupServiceAccountIdentifier = $mockGsaWidResource.GroupServiceAccountIdentifier
+            ServiceAccountCredential      = $mockGsaWidResource.ServiceAccountCredential
+            PrimaryComputerName           = $mockGsaWidResource.PrimaryComputerName
+            PrimaryComputerPort           = $mockGsaWidResource.PrimaryComputerPort
+            SQLConnectionString           = $mockGsaWidResource.SQLConnectionString
         }
 
-        $mockGetTargetResourcePresentResult = $mockGetTargetResourceResult.Clone()
-        $mockGetTargetResourcePresentResult.Ensure = 'Present'
+        $mockGetTargetGsaWidResourcePresentResult = $mockGetTargetGsaWidResourceResult.Clone()
+        $mockGetTargetGsaWidResourcePresentResult.Ensure = 'Present'
 
-        $mockGetTargetResourceAbsentResult = $MockGetTargetResourceResult.Clone()
+        $mockGetTargetResourceAbsentResult = $mockGetTargetGsaWidResourceResult.Clone()
         $mockGetTargetResourceAbsentResult.Ensure = 'Absent'
 
         $getTargetResourceParameters = @{
-            FederationServiceName = $mockResource.FederationServiceName
-            CertificateThumbprint = $mockResource.CertificateThumbprint
+            FederationServiceName = $mockWidResource.FederationServiceName
+            CertificateThumbprint = $mockWidResource.CertificateThumbprint
             Credential            = $mockCredential
         }
 
@@ -102,18 +115,18 @@ try
                 @{
                     Hostname        = 'sts.contoso.com'
                     PortNumber      = 443
-                    CertificateHash = $mockResource.CertificateThumbprint
+                    CertificateHash = $mockWidResource.CertificateThumbprint
                 }
             )
 
-            $mockGetAdfsSyncProperties = @{
-                PrimaryComputerName = $mockResource.PrimaryComputerName
-                PrimaryComputerPort = $mockResource.PrimaryComputerPort
+            $mockGetAdfsSyncPropertiesWid = @{
+                PrimaryComputerName = $mockWidResource.PrimaryComputerName
+                PrimaryComputerPort = $mockWidResource.PrimaryComputerPort
             }
 
             $mockGetCimInstanceServiceGsaRunningResult = @{
                 State     = 'Running'
-                StartName = $mockGsaResource.GroupServiceAccountIdentifier
+                StartName = $mockGsaWidResource.GroupServiceAccountIdentifier
             }
 
             $mockGetCimInstanceServiceSaRunningResult = @{
@@ -137,134 +150,182 @@ try
                     $ClassName -eq 'SecurityTokenService' } `
                 -MockWith { $mockGetCimInstanceSecurityTokenServiceResult }
             Mock -CommandName Get-AdfsSslCertificate -MockWith { $mockGetAdfsSslCertificateResult }
-            Mock -CommandName Get-AdfsSyncProperties -MockWith { $mockGetAdfsSyncProperties }
+            Mock -CommandName Get-AdfsSyncProperties
             Mock -CommandName Assert-GroupServiceAccount -MockWith { $true }
+            Mock -CommandName Get-ObjectType -MockWith { $script:syncPropertiesTypeName }
 
             Context "When the $($Global:DscResourceFriendlyName) Resource is configured" {
                 BeforeAll {
                     Mock -CommandName $ResourceCommand.Get -MockWith { 'Configured' }
-
-                    $result = Get-TargetResource @getTargetResourceParameters
                 }
 
-                foreach ($property in $mockGsaResource.Keys)
-                {
-                    It "Should return the correct $property property" {
-                        $result.$property | Should -Be $mockGsaResource.$property
-                    }
-                }
-
-                It 'Should call the expected mocks' {
-                    Assert-MockCalled -CommandName Assert-Module `
-                        -ParameterFilter { $ModuleName -eq $Global:PSModuleName } `
-                        -Exactly -Times 1
-                    Assert-MockCalled -CommandName Assert-DomainMember -Exactly -Times 1
-                    Assert-MockCalled -CommandName Assert-AdfsService -Exactly -Times 1
-                    Assert-MockCalled -CommandName $ResourceCommand.Get -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance `
-                        -ParameterFilter {
-                        $ClassName -eq 'Win32_Service' -and `
-                            $Filter -eq "Name='$script:AdfsServiceName'" } `
-                        -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-CimInstance `
-                        -ParameterFilter {
-                        $Namespace -eq 'root/ADFS' -and `
-                            $ClassName -eq 'SecurityTokenService' } `
-                        -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-AdfsSslCertificate -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-AdfsSyncProperties -Exactly -Times 1
-                    Assert-MockCalled -CommandName Assert-GroupServiceAccount -Exactly -Times 1
-                }
-
-                Context 'When Get-AdfsSslCertificate throws an exception' {
+                Context "When the configured database is WID" {
                     BeforeAll {
-                        Mock Get-AdfsSslCertificate -MockWith { throw $mockExceptionErrorMessage }
-                    }
-
-                    It 'Should throw the correct exception' {
-                        { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
-                            $script:localizedData.GettingAdfsSslCertificateError -f
-                            $mockResource.FederationServiceName)
-                    }
-                }
-
-                Context 'When Get-AdfsSslCertificate returns an empty result' {
-                    BeforeAll {
-                        Mock Get-AdfsSslCertificate
-                    }
-
-                    It 'Should throw the correct exception' {
-                        { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
-                            $script:localizedData.GettingAdfsSslCertificateError -f
-                            $mockResource.FederationServiceName)
-                    }
-                }
-
-                Context 'When Get-CimInstance -ClassName Win32_Service returns an empty result' {
-                    BeforeAll {
-                        Mock -CommandName Get-CimInstance `
-                            -ParameterFilter { $ClassName -eq 'Win32_Service' }
-                    }
-
-                    It 'Should throw the correct exception' {
-                        { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
-                            $script:localizedData.GettingAdfsServiceError -f
-                            $mockResource.FederationServiceName)
-                    }
-                }
-
-                Context 'When the Service Account is not a group managed service account' {
-                    BeforeAll {
-                        Mock -CommandName Get-CimInstance `
-                            -ParameterFilter { $ClassName -eq 'Win32_Service' } `
-                            -MockWith { $mockGetCimInstanceServiceSaRunningResult }
-                        Mock -CommandName Assert-GroupServiceAccount -MockWith { $false }
+                        Mock -CommandName Get-AdfsSyncProperties -MockWith { $mockGetAdfsSyncPropertiesWid }
+                        Mock -CommandName Get-ObjectType -MockWith { $script:syncPropertiesTypeName }
 
                         $result = Get-TargetResource @getTargetResourceParameters
                     }
 
-                    foreach ($property in $mockSaResource.Keys)
+                    foreach ($property in $mockGsaWidResource.Keys)
                     {
-                        if ($property -eq 'ServiceAccountCredential')
-                        {
-                            It "Should return the correct $property property" {
-                                $result.ServiceAccountCredential.UserName | Should -Be $mockSaResource.ServiceAccountCredential.UserName
-                            }
-                        }
-                        else
-                        {
-                            It "Should return the correct $property property" {
-                                $result.$property | Should -Be $mockSaResource.$property
-                            }
+                        It "Should return the correct $property property" {
+                            $result.$property | Should -Be $mockGsaWidResource.$property
                         }
                     }
-                }
 
-                Context 'When Get-CimInstance -ClassName SecurityTokenService throws an exception' {
-                    BeforeAll {
-                        Mock -CommandName Get-CimInstance `
-                            -ParameterFilter { `
-                                $Namespace -eq 'root/ADFS' -and `
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Assert-Module `
+                            -ParameterFilter { $ModuleName -eq $Global:PSModuleName } `
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Assert-DomainMember -Exactly -Times 1
+                        Assert-MockCalled -CommandName Assert-AdfsService -Exactly -Times 1
+                        Assert-MockCalled -CommandName $ResourceCommand.Get -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-CimInstance `
+                            -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and `
+                                $Filter -eq "Name='$script:AdfsServiceName'" } `
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-CimInstance `
+                            -ParameterFilter {
+                            $Namespace -eq 'root/ADFS' -and `
                                 $ClassName -eq 'SecurityTokenService' } `
-                            -MockWith { throw $mockExceptionErrorMessage }
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-AdfsSslCertificate -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-AdfsSyncProperties -Exactly -Times 1
+                        Assert-MockCalled -CommandName Assert-GroupServiceAccount -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-ObjectType -Exactly -Times 1
                     }
 
-                    It 'Should throw the correct exception' {
-                        { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
-                            $script:localizedData.GettingAdfsSecurityTokenServiceError -f
-                            $mockResource.FederationServiceName)
+                    Context 'When Get-AdfsSslCertificate throws an exception' {
+                        BeforeAll {
+                            Mock Get-AdfsSslCertificate -MockWith { throw $mockExceptionErrorMessage }
+                        }
+
+                        It 'Should throw the correct exception' {
+                            { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
+                                $script:localizedData.GettingAdfsSslCertificateError -f
+                                $mockWidResource.FederationServiceName)
+                        }
+                    }
+
+                    Context 'When Get-AdfsSslCertificate returns an empty result' {
+                        BeforeAll {
+                            Mock Get-AdfsSslCertificate
+                        }
+
+                        It 'Should throw the correct exception' {
+                            { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
+                                $script:localizedData.GettingAdfsSslCertificateError -f
+                                $mockWidResource.FederationServiceName)
+                        }
+                    }
+
+                    Context 'When Get-CimInstance -ClassName Win32_Service returns an empty result' {
+                        BeforeAll {
+                            Mock -CommandName Get-CimInstance `
+                                -ParameterFilter { $ClassName -eq 'Win32_Service' }
+                        }
+
+                        It 'Should throw the correct exception' {
+                            { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
+                                $script:localizedData.GettingAdfsServiceError -f
+                                $mockWidResource.FederationServiceName)
+                        }
+                    }
+
+                    Context 'When the Service Account is not a group managed service account' {
+                        BeforeAll {
+                            Mock -CommandName Get-CimInstance `
+                                -ParameterFilter { $ClassName -eq 'Win32_Service' } `
+                                -MockWith { $mockGetCimInstanceServiceSaRunningResult }
+                            Mock -CommandName Assert-GroupServiceAccount -MockWith { $false }
+
+                            $result = Get-TargetResource @getTargetResourceParameters
+                        }
+
+                        foreach ($property in $mockSaResource.Keys)
+                        {
+                            if ($property -eq 'ServiceAccountCredential')
+                            {
+                                It "Should return the correct $property property" {
+                                    $result.ServiceAccountCredential.UserName | Should -Be $mockSaResource.ServiceAccountCredential.UserName
+                                }
+                            }
+                            else
+                            {
+                                It "Should return the correct $property property" {
+                                    $result.$property | Should -Be $mockSaResource.$property
+                                }
+                            }
+                        }
+                    }
+
+                    Context 'When Get-CimInstance -ClassName SecurityTokenService throws an exception' {
+                        BeforeAll {
+                            Mock -CommandName Get-CimInstance `
+                                -ParameterFilter { `
+                                    $Namespace -eq 'root/ADFS' -and `
+                                    $ClassName -eq 'SecurityTokenService' } `
+                                -MockWith { throw $mockExceptionErrorMessage }
+                        }
+
+                        It 'Should throw the correct exception' {
+                            { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
+                                $script:localizedData.GettingAdfsSecurityTokenServiceError -f
+                                $mockWidResource.FederationServiceName)
+                        }
+                    }
+
+                    Context 'When Get-AdfsSyncProperties throws an exception' {
+                        BeforeAll {
+                            Mock Get-AdfsSyncProperties -MockWith { throw $mockExceptionErrorMessage }
+                        }
+
+                        It 'Should throw the correct exception' {
+                            { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
+                                $script:localizedData.GettingAdfsSyncPropertiesError -f
+                                $mockWidResource.FederationServiceName)
+                        }
                     }
                 }
 
-                Context 'When Get-AdfsSyncProperties throws an exception' {
+                Context "When the configured database is SQL" {
                     BeforeAll {
-                        Mock Get-AdfsSyncProperties -MockWith { throw $mockExceptionErrorMessage }
+                        Mock -CommandName Get-AdfsSyncProperties
+                        Mock -CommandName Get-ObjectType -MockWith { $script:syncPropertiesBaseTypeName }
+
+                        $result = Get-TargetResource @getTargetResourceParameters
                     }
 
-                    It 'Should throw the correct exception' {
-                        { Get-TargetResource @getTargetResourceParameters } | Should -Throw (
-                            $script:localizedData.GettingAdfsSyncPropertiesError -f
-                            $mockResource.FederationServiceName)
+                    foreach ($property in $mockGsaSqlResource.Keys)
+                    {
+                        It "Should return the correct $property property" {
+                            $result.$property | Should -Be $mockGsaSqlResource.$property
+                        }
+                    }
+
+                    It 'Should call the expected mocks' {
+                        Assert-MockCalled -CommandName Assert-Module `
+                            -ParameterFilter { $ModuleName -eq $Global:PSModuleName } `
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Assert-DomainMember -Exactly -Times 1
+                        Assert-MockCalled -CommandName Assert-AdfsService -Exactly -Times 1
+                        Assert-MockCalled -CommandName $ResourceCommand.Get -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-CimInstance `
+                            -ParameterFilter {
+                            $ClassName -eq 'Win32_Service' -and `
+                                $Filter -eq "Name='$script:AdfsServiceName'" } `
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-CimInstance `
+                            -ParameterFilter {
+                            $Namespace -eq 'root/ADFS' -and `
+                                $ClassName -eq 'SecurityTokenService' } `
+                            -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-AdfsSslCertificate -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-AdfsSyncProperties -Exactly -Times 1
+                        Assert-MockCalled -CommandName Assert-GroupServiceAccount -Exactly -Times 1
+                        Assert-MockCalled -CommandName Get-ObjectType -Exactly -Times 1
                     }
                 }
             }
@@ -276,7 +337,7 @@ try
                     $result = Get-TargetResource @getTargetResourceParameters
                 }
 
-                foreach ($property in $mockGsaResource.Keys)
+                foreach ($property in $mockGsaWidResource.Keys)
                 {
                     It "Should return the correct $property property" {
                         $result.$property | Should -Be $mockAbsentResource.$property
@@ -295,6 +356,7 @@ try
                     Assert-MockCalled -CommandName Get-AdfsSslCertificate -Exactly -Times 0
                     Assert-MockCalled -CommandName Get-AdfsSyncProperties -Exactly -Times 0
                     Assert-MockCalled -CommandName Assert-GroupServiceAccount -Exactly -Times 0
+                    Assert-MockCalled -CommandName Get-ObjectType -Exactly -Times 0
                 }
             }
         }
@@ -302,10 +364,10 @@ try
         Describe "$Global:DSCResourceName\Set-TargetResource" -Tag 'Set' {
             BeforeAll {
                 $setTargetResourceParameters = @{
-                    FederationServiceName         = $mockGsaResource.FederationServiceName
+                    FederationServiceName         = $mockGsaWidResource.FederationServiceName
                     Credential                    = $mockCredential
-                    CertificateThumbprint         = $mockGsaResource.CertificateThumbprint
-                    GroupServiceAccountIdentifier = $mockGsaResource.GroupServiceAccountIdentifier
+                    CertificateThumbprint         = $mockGsaWidResource.CertificateThumbprint
+                    GroupServiceAccountIdentifier = $mockGsaWidResource.GroupServiceAccountIdentifier
                     PrimaryComputerName           = 'ADFS01'
                     PrimaryComputerPort           = 443
                 }
@@ -340,8 +402,8 @@ try
 
                 It 'Should throw the correct error' {
                     { Set-TargetResource @setTargetResourceBothCredentialParameters } |
-                        Should -Throw ($script:localizedData.ResourceDuplicateCredentialError -f
-                            $setTargetResourceBothCredentialParameters.FederationServiceName)
+                    Should -Throw ($script:localizedData.ResourceDuplicateCredentialError -f
+                        $setTargetResourceBothCredentialParameters.FederationServiceName)
                 }
             }
 
@@ -353,8 +415,8 @@ try
 
                 It 'Should throw the correct error' {
                     { Set-TargetResource @setTargetResourceBothCredentialParameters } |
-                        Should -Throw ($script:localizedData.ResourceMissingCredentialError -f
-                            $setTargetResourceBothCredentialParameters.FederationServiceName)
+                    Should -Throw ($script:localizedData.ResourceMissingCredentialError -f
+                        $setTargetResourceBothCredentialParameters.FederationServiceName)
                 }
             }
 
@@ -424,7 +486,7 @@ try
 
                 Context "When the $($Global:DscResourceFriendlyName) Resource is installed" {
                     BeforeAll {
-                        Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourcePresentResult }
+                        Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetGsaWidResourcePresentResult }
                     }
 
                     It 'Should not throw' {
@@ -437,7 +499,7 @@ try
 
                 Context "When the $($Global:DscResourceFriendlyName) Resource is installed" {
                     BeforeAll {
-                        Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourcePresentResult }
+                        Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetGsaWidResourcePresentResult }
                     }
 
                     It 'Should not throw' {
@@ -482,12 +544,12 @@ try
         Describe "$Global:DSCResourceName\Test-TargetResource" -Tag 'Test' {
             BeforeAll {
                 $testTargetResourceParameters = @{
-                    FederationServiceName         = $mockGsaResource.FederationServiceName
+                    FederationServiceName         = $mockGsaWidResource.FederationServiceName
                     Credential                    = $mockCredential
-                    CertificateThumbprint         = $mockGsaResource.CertificateThumbprint
-                    GroupServiceAccountIdentifier = $mockGsaResource.GroupServiceAccountIdentifier
-                    PrimaryComputerName           = $mockGsaResource.PrimaryComputerName
-                    PrimaryComputerPort           = $mockGsaResource.PrimaryComputerPort
+                    CertificateThumbprint         = $mockGsaWidResource.CertificateThumbprint
+                    GroupServiceAccountIdentifier = $mockGsaWidResource.GroupServiceAccountIdentifier
+                    PrimaryComputerName           = $mockGsaWidResource.PrimaryComputerName
+                    PrimaryComputerPort           = $mockGsaWidResource.PrimaryComputerPort
                 }
 
                 $testTargetResourcePresentParameters = $testTargetResourceParameters.Clone()
@@ -499,7 +561,7 @@ try
 
             Context "When the $($Global:DscResourceFriendlyName) Resource is installed" {
                 BeforeAll {
-                    Mock Get-TargetResource -MockWith { $mockGetTargetResourcePresentResult }
+                    Mock Get-TargetResource -MockWith { $mockGetTargetGsaWidResourcePresentResult }
                 }
 
                 Context "When the $($Global:DscResourceFriendlyName) Resource should be installed" {

--- a/Tests/Unit/Stubs/AdfsStub.psm1
+++ b/Tests/Unit/Stubs/AdfsStub.psm1
@@ -710,6 +710,29 @@ namespace Microsoft.IdentityServer.Management.Resources
         }
     }
 
+    public class SyncProperties
+    {
+        // Constructor
+        public SyncProperties() { }
+
+        // Property
+        public System.String LastSyncFromPrimaryComputerName { get; set; }
+        public System.Int32 LastSyncStatus { get; set; }
+        public System.DateTime LastSyncTime { get; set; }
+        public System.Int32 PollDuration { get; set; }
+        public System.String PrimaryComputerName { get; set; }
+        public System.Int32 PrimaryComputerPort { get; set; }
+        public System.String Role { get; set; }
+    }
+
+    public class SyncPropertiesBase
+    {
+        // Constructor
+        public SyncPropertiesBase() { }
+
+        // Property
+        public System.String Role { get; set; }
+    }
 }
 
 namespace Microsoft.IdentityServer.PolicyModel.Configuration
@@ -825,7 +848,6 @@ namespace Microsoft.IdentityServer.Protocols.PolicyStore
     }
 
 }
-
 '@
 
 function Add-AdfsAttributeStore {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@
 #---------------------------------#
 
 version: 2.16.{build}.0
-branches:
-    only:
-    - master
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: |


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the `AdfsFarmNode` resource so that `AdfsSyncProperties` are correctly handled when using a remote SQL database.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
