### PR TITLE
AdfsDsc: Set StrictMode on Integration Tests

### DIFF
--- a/Tests/Integration/MSFT_AdfsApplicationGroup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_AdfsApplicationGroup.Integration.Tests.ps1
@@ -3,6 +3,8 @@
         AdfsApplicationGroup DSC Resource Integration Tests
 #>
 
+Set-StrictMode -Version 2.0
+
 if ($env:APPVEYOR -eq $true)
 {
     Write-Warning -Message 'Integration test is not supported in AppVeyor.'

--- a/Tests/Integration/MSFT_AdfsApplicationPermission.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_AdfsApplicationPermission.Integration.Tests.ps1
@@ -7,6 +7,8 @@
         AdfsNativeClientApplication and AdsWebApiApplication resource.
 #>
 
+Set-StrictMode -Version 2.0
+
 if ($env:APPVEYOR -eq $true)
 {
     Write-Warning -Message 'Integration test is not supported in AppVeyor.'

--- a/Tests/Integration/MSFT_AdfsClaimDescription.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_AdfsClaimDescription.Integration.Tests.ps1
@@ -3,6 +3,8 @@
         AdfsClaimDescription DSC Resource Integration Tests
 #>
 
+Set-StrictMode -Version 2.0
+
 if ($env:APPVEYOR -eq $true)
 {
     Write-Warning -Message 'Integration test is not supported in AppVeyor.'

--- a/Tests/Integration/MSFT_AdfsFarm.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_AdfsFarm.Integration.Tests.ps1
@@ -3,6 +3,8 @@
         AdfsFarm DSC Resource Integration Tests
 #>
 
+Set-StrictMode -Version 2.0
+
 if ($env:APPVEYOR -eq $true)
 {
     Write-Warning -Message 'Integration test is not supported in AppVeyor.'

--- a/Tests/Integration/MSFT_AdfsNativeClientApplication.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_AdfsNativeClientApplication.Integration.Tests.ps1
@@ -6,6 +6,8 @@
         The AdfsNativeClientApplication resource has a dependency on an AdfsApplicationGroup resource
 #>
 
+Set-StrictMode -Version 2.0
+
 if ($env:APPVEYOR -eq $true)
 {
     Write-Warning -Message 'Integration test is not supported in AppVeyor.'

--- a/Tests/Integration/MSFT_AdfsWebApiApplication.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_AdfsWebApiApplication.Integration.Tests.ps1
@@ -6,6 +6,8 @@
         The AdfsWebApiApplication resource has a dependency on an AdfsApplicationGroup resource
 #>
 
+Set-StrictMode -Version 2.0
+
 if ($env:APPVEYOR -eq $true)
 {
     Write-Warning -Message 'Integration test is not supported in AppVeyor.'


### PR DESCRIPTION
#### Pull Request (PR) description

This PR sets `StrictMode` to version 2.0 on all resource integration tests.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-guardian/adfsdsc/17)
<!-- Reviewable:end -->
