### PR TITLE
AdfsOrganization: Add Empty Organization Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Added empty contact support ([issue #27](https://github.com/X-Guardian/AdfsDsc/issues/27)).
 - Changes to AdfsGlobalAuthenticationPolicy
   - Added integration tests.
+- Changes to AdfsOrganization
+  - Added empty organization support ([issue #30](https://github.com/X-Guardian/AdfsDsc/issues/30)).
 
 ## 1.0.0
 

--- a/DSCResources/MSFT_AdfsOrganization/MSFT_AdfsOrganization.psm1
+++ b/DSCResources/MSFT_AdfsOrganization/MSFT_AdfsOrganization.psm1
@@ -103,8 +103,6 @@ function Get-TargetResource
 
     if ($targetResource -is [Microsoft.IdentityServer.Management.Resources.Organization])
     {
-        Write-Debug -Message 'Organization object returned in OrganizationInfo from Get-AdfsProperties'
-
         $returnValue = @{
             FederationServiceName = $FederationServiceName
             Name                  = $targetResource.Name
@@ -114,8 +112,6 @@ function Get-TargetResource
     }
     else
     {
-        Write-Debug -Message 'Organization object not returned in OrganizationInfo from Get-AdfsProperties'
-
         $returnValue = @{
             FederationServiceName = $FederationServiceName
             Name                  = ''

--- a/DSCResources/MSFT_AdfsOrganization/MSFT_AdfsOrganization.psm1
+++ b/DSCResources/MSFT_AdfsOrganization/MSFT_AdfsOrganization.psm1
@@ -62,14 +62,17 @@ function Get-TargetResource
         $FederationServiceName,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $DisplayName,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $OrganizationUrl
     )
@@ -98,11 +101,27 @@ function Get-TargetResource
         New-InvalidOperationException -Message $errorMessage -Error $_
     }
 
-    $returnValue = @{
-        FederationServiceName = $FederationServiceName
-        Name                  = $targetResource.Name
-        DisplayName           = $targetResource.DisplayName
-        OrganizationUrl       = $targetResource.OrganizationUrl
+    if ($targetResource -is [Microsoft.IdentityServer.Management.Resources.Organization])
+    {
+        Write-Debug -Message 'Organization object returned in OrganizationInfo from Get-AdfsProperties'
+
+        $returnValue = @{
+            FederationServiceName = $FederationServiceName
+            Name                  = $targetResource.Name
+            DisplayName           = $targetResource.DisplayName
+            OrganizationUrl       = $targetResource.OrganizationUrl
+        }
+    }
+    else
+    {
+        Write-Debug -Message 'Organization object not returned in OrganizationInfo from Get-AdfsProperties'
+
+        $returnValue = @{
+            FederationServiceName = $FederationServiceName
+            Name                  = ''
+            DisplayName           = ''
+            OrganizationUrl       = ''
+        }
     }
 
     $returnValue
@@ -132,14 +151,17 @@ function Set-TargetResource
         $FederationServiceName,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $DisplayName,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $OrganizationUrl
     )
@@ -175,14 +197,23 @@ function Set-TargetResource
             $FederationServiceName, $property.ParameterName, ($property.Expected -join ', '))
     }
 
-    try
+    # Set organization to $null if all parameters are empty
+    if ([System.String]::IsNullOrEmpty($DisplayName) -and [System.String]::IsNullOrEmpty($Name) -and
+        [System.String]::IsNullOrEmpty($OrganizationUrl))
     {
-        $organizationInfo = New-AdfsOrganization @parameters
+        $organizationInfo = $null
     }
-    catch
+    else
     {
-        $errorMessage = $script:localizedData.NewAdfsOrganizationErrorMessage -f $FederationServiceName
-        New-InvalidOperationException -Message $errorMessage -Error $_
+        try
+        {
+            $organizationInfo = New-AdfsOrganization @parameters
+        }
+        catch
+        {
+            $errorMessage = $script:localizedData.NewAdfsOrganizationErrorMessage -f $FederationServiceName
+            New-InvalidOperationException -Message $errorMessage -Error $_
+        }
     }
 
     try
@@ -219,14 +250,17 @@ function Test-TargetResource
         $FederationServiceName,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $DisplayName,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $Name,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [System.String]
         $OrganizationUrl
     )

--- a/Examples/Resources/AdfsOrganization/1-AdfsOrganization_Config.ps1
+++ b/Examples/Resources/AdfsOrganization/1-AdfsOrganization_Config.ps1
@@ -34,7 +34,7 @@ Configuration AdfsOrganization_Config
             FederationServiceName = 'sts.contoso.com'
             DisplayName           = 'Contoso Inc.'
             Name                  = 'Contoso'
-            OrganizationUrl       = 'https://www.contoso.com'
+            OrganizationUrl       = 'https://www.contoso.com/'
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds read/write support for an empty contact to the `AdfsOrganization` resource.

#### This Pull Request (PR) fixes the following issues

- Fixes #30 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-guardian/adfsdsc/31)
<!-- Reviewable:end -->
