### PR TITLE
AdfsProperties: Remove Obsolete Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Added integration tests.
 - Changes to AdfsProperties
   - Added integration tests.
+  - Remove obsolete properties PromptLoginFederation and PromptLoginFallbackAuthenticationType ([issue #34](https://github.com/X-Guardian/AdfsDsc/issues/34)).
 
 ## 1.0.0
 

--- a/DSCResources/MSFT_AdfsProperties/MSFT_AdfsProperties.psm1
+++ b/DSCResources/MSFT_AdfsProperties/MSFT_AdfsProperties.psm1
@@ -76,10 +76,6 @@
         (1440) as a multiplier. Change this value only if you want to use a more finely detailed measure of time, such
         as less than a single day, for calculating the time periods for other certificate threshold parameters.
 
-    .PARAMETER ContactPerson
-        ** Not Currently Implemented **
-        Specifies the contact information for support issues.
-
     .PARAMETER EnableOAuthDeviceFlow
         Write - Boolean
         Enabled the OAuth Device Flow.
@@ -130,10 +126,6 @@
         Indicates whether to enable support for NTLM-based authentication in situations where the active federation
         server proxy does not support Negotiate method of authentication. This setting only affects the Windows
         transport endpoint.
-
-    .PARAMETER Organization
-        ** Not Currently Implemented **
-        Specifies the organization that is published in the federation metadata for the Federation Service.
 
     .PARAMETER PreventTokenReplays
         Write - Boolean
@@ -322,20 +314,6 @@
     .PARAMETER IdTokenIssuer
         Write - String
         Specifies the URI of the token issuer.
-
-    .PARAMETER PromptLoginFederation
-        Write - String
-        Allowed values: None, FallbackToProtocolSpecificParameters, ForwardPromptAndHintsOverWsFederation, Disabled
-        Specifies the process to use if the prompt=login query parameter is specified.
-
-    .PARAMETER PromptLoginFallbackAuthenticationType
-        Write - String
-        Specifies a fallback authentication type for a prompt login request.
-
-    .NOTES
-        Todo:
-            - ContactPerson parameter [Microsoft.IdentityServer.PowerShell.Resources.ContactPerson]
-            - Organization parameter [Microsoft.IdentityServer.PowerShell.Resources.Organization]
 #>
 
 Set-StrictMode -Version 2.0
@@ -462,8 +440,6 @@ function Get-TargetResource
         EnableIdPInitiatedSignonPage               = $targetResource.EnableIdPInitiatedSignonPage
         IgnoreTokenBinding                         = $targetResource.IgnoreTokenBinding
         IdTokenIssuer                              = $targetResource.IdTokenIssuer
-        PromptLoginFederation                      = $targetResource.PromptLoginFederation
-        PromptLoginFallbackAuthenticationType      = $targetResource.PromptLoginFallbackAuthenticationType
     }
 
     $returnValue
@@ -730,19 +706,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $IdTokenIssuer,
-
-        [Parameter()]
-        [ValidateSet('None',
-            'FallbackToProtocolSpecificParameters',
-            'ForwardPromptAndHintsOverWsFederation',
-            'Disabled')]
-        [System.String]
-        $PromptLoginFederation,
-
-        [Parameter()]
-        [System.String]
-        $PromptLoginFallbackAuthenticationType
+        $IdTokenIssuer
     )
 
     # Set Verbose and Debug parameters
@@ -1049,19 +1013,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $IdTokenIssuer,
-
-        [Parameter()]
-        [ValidateSet('None',
-            'FallbackToProtocolSpecificParameters',
-            'ForwardPromptAndHintsOverWsFederation',
-            'Disabled')]
-        [System.String]
-        $PromptLoginFederation,
-
-        [Parameter()]
-        [System.String]
-        $PromptLoginFallbackAuthenticationType
+        $IdTokenIssuer
     )
 
     # Set Verbose and Debug parameters

--- a/DSCResources/MSFT_AdfsProperties/MSFT_AdfsProperties.schema.mof
+++ b/DSCResources/MSFT_AdfsProperties/MSFT_AdfsProperties.schema.mof
@@ -62,6 +62,4 @@ class MSFT_AdfsProperties : OMI_BaseResource
     [Write, Description("Specifies whether to enable the EnableIdPInitiatedSignonPage property.")] Boolean EnableIdPInitiatedSignonPage;
     [Write, Description("Specifies whether to ignore token binding.")] Boolean IgnoreTokenBinding;
     [Write, Description("Specifies the URI of the token issuer.")] String IdTokenIssuer;
-    [Write, Description("Specifies the process to use if the prompt=login query parameter is specified."), ValueMap{"None","FallbackToProtocolSpecificParameters","ForwardPromptAndHintsOverWsFederation","Disabled"}, Values{"None","FallbackToProtocolSpecificParameters","ForwardPromptAndHintsOverWsFederation","Disabled"}] String PromptLoginFederation;
-    [Write, Description("Specifies a fallback authentication type for a prompt login request.")] String PromptLoginFallbackAuthenticationType;
 };

--- a/Tests/Unit/MSFT_AdfsProperties.Tests.ps1
+++ b/Tests/Unit/MSFT_AdfsProperties.Tests.ps1
@@ -90,8 +90,6 @@ try
             EnableIdPInitiatedSignonPage               = $false
             IgnoreTokenBinding                         = $false
             IdTokenIssuer                              = 'https://sts.contoso.com/adfs'
-            PromptLoginFederation                      = 'FallbackToProtocolSpecificParameters'
-            PromptLoginFallbackAuthenticationType      = 'urn:oasis:names:tc:SAML:1.0:am:password'
         }
 
         $mockChangedResource = @{
@@ -154,8 +152,6 @@ try
             EnableIdPInitiatedSignonPage               = $true
             IgnoreTokenBinding                         = $true
             IdTokenIssuer                              = 'https://sts.fabrikam.com/adfs'
-            PromptLoginFederation                      = 'Disabled'
-            PromptLoginFallbackAuthenticationType      = 'urn:oasis:names:tc:SAML:1.0:am:password2'
         }
 
         $mockGetTargetResourceResult = @{
@@ -219,8 +215,6 @@ try
             EnableIdPInitiatedSignonPage               = $mockResource.EnableIdPInitiatedSignonPage
             IgnoreTokenBinding                         = $mockResource.IgnoreTokenBinding
             IdTokenIssuer                              = $mockResource.IdTokenIssuer
-            PromptLoginFederation                      = $mockResource.PromptLoginFederation
-            PromptLoginFallbackAuthenticationType      = $mockResource.PromptLoginFallbackAuthenticationType
         }
 
         Describe 'MSFT_AdfsProperties\Get-TargetResource' -Tag 'Get' {
@@ -290,8 +284,6 @@ try
                     EnableIdpInitiatedSignonPage               = $mockResource.EnableIdpInitiatedSignonPage
                     IgnoreTokenBinding                         = $mockResource.IgnoreTokenBinding
                     EnableOauthDeviceFlow                      = $mockResource.EnableOauthDeviceFlow
-                    PromptLoginFederation                      = $mockResource.PromptLoginFederation
-                    PromptLoginFallbackAuthenticationType      = $mockResource.PromptLoginFallbackAuthenticationType
                 }
 
                 Mock -CommandName Assert-Module
@@ -388,8 +380,6 @@ try
                     EnableIdPInitiatedSignonPage               = $mockResource.EnableIdPInitiatedSignonPage
                     IgnoreTokenBinding                         = $mockResource.IgnoreTokenBinding
                     IdTokenIssuer                              = $mockResource.IdTokenIssuer
-                    PromptLoginFederation                      = $mockResource.PromptLoginFederation
-                    PromptLoginFallbackAuthenticationType      = $mockResource.PromptLoginFallbackAuthenticationType
                 }
 
                 Mock -CommandName $ResourceCommand.Set


### PR DESCRIPTION
#### Pull Request (PR) description

This PR removes the obsolete properties `PromptLoginFederation` and `PromptLoginFallbackAuthenticationType` from the `AdfsProperties` resource.

#### This Pull Request (PR) fixes the following issues

- Fixes #34 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-guardian/adfsdsc/35)
<!-- Reviewable:end -->
