### PR TITLE
BREAKING CHANGE: AdfsFarmNode: Remove Ensure Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Changes to AdfsProperties
   - Added integration tests.
   - Remove obsolete properties PromptLoginFederation and PromptLoginFallbackAuthenticationType ([issue #34](https://github.com/X-Guardian/AdfsDsc/issues/34)).
+- Changes to AdfsFarmNode
+  - Removed Ensure Parameter as Remove-AdfsFarmNode cmdlet is deprecated ([issue #36](https://github.com/X-Guardian/AdfsDsc/issues/36)).
 
 ## 1.0.0
 

--- a/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.schema.mof
+++ b/DSCResources/MSFT_AdfsFarmNode/MSFT_AdfsFarmNode.schema.mof
@@ -10,5 +10,5 @@ class MSFT_AdfsFarmNode : OMI_BaseResource
     [Write, Description("Specifies the primary computer port. The computer uses the HTTP port that you specify to connect with the primary computer in order to synchronize configuration settings. Specify a value of 80 for this parameter, or specify an alternate value if the HTTP port on the primary computer is not 80. If this parameter is not specified, a default port value of 80 is assumed.")] Sint32 PrimaryComputerPort;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Specifies the Active Directory account under which the AD FS service runs. All nodes in the farm must use the same service account.")] String ServiceAccountCredential;
     [Write, Description("Specifies the SQL Server database that will store the AD FS configuration settings. If not specified, AD FS uses Windows Internal Database to store configuration settings.")] String SQLConnectionString;
-    [Write, Description("Specifies whether the ADFS Farm Node should be present or absent. Default value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Read, Description("The state of the ADFS Farm.")] String Ensure;
 };

--- a/DSCResources/MSFT_AdfsFarmNode/en-US/MSFT_AdfsFarmNode.strings.psd1
+++ b/DSCResources/MSFT_AdfsFarmNode/en-US/MSFT_AdfsFarmNode.strings.psd1
@@ -6,13 +6,10 @@ ConvertFrom-StringData @'
     InstallingResourceMessage                       = Installing '{0}'. (NDE004)
     ResourceInstallSuccessMessage                   = '{0}' has been installed successfully. A reboot is now required. (NDE005)
     ResourceInDesiredStateMessage                   = '{0}' is in the desired state. (NDE006)
-    ResourceIsPresentButShouldBeAbsentMessage       = '{0}' is present but should be absent. (NDE007)
-    ResourceIsAbsentButShouldBePresentMessage       = '{0}' is absent but should be present. (NDE008)
+    ResourceIsAbsentButShouldBePresentMessage       = '{0}' is absent but should be present. (NDE007)
     MissingAdfsAssembliesMessage                    = Required ADFS assemblies can't be found. Reboot required. (NDE009)
-    RemovingResourceMessage                         = Removing '{0}'. (NDE010)
 
     InstallationErrorMessage                        = '{0}' installation error. (NDEERR001)
-    RemovalErrorMessage                             = '{0}' removal error. (NDEERR002)
     ResourceDuplicateCredentialErrorMessage         = Only one of the credential parameters 'ServiceAccountCredential' or 'GroupServiceAccountIdentifier' should be specified for '{0}'. (NDEERR003)
     ResourceMissingCredentialErrorMessage           = One of the credential parameters 'ServiceAccountCredential' or 'GroupServiceAccountIdentifier' must be specified for '{0}'. (NDEERR004)
     GettingAdfsSslCertificateErrorMessage           = Error getting the ADFS SSL Certificate for '{0}'. (NDEERR005)
@@ -23,6 +20,4 @@ ConvertFrom-StringData @'
 
     TargetResourcePresentDebugMessage               = '{0}' is Present. (NDEDBG001)
     TargetResourceAbsentDebugMessage                = '{0}' is Absent. (NDEDBG002)
-    TargetResourceShouldBePresentDebugMessage       = '{0}' should be Present. (NDEDBG003)
-    TargetResourceShouldBeAbsentDebugMessage        = '{0}' should be Absent. (NDEDBG004)
 '@

--- a/DSCResources/MSFT_AdfsFarmNode/en-US/about_AdfsFarmNode.help.txt
+++ b/DSCResources/MSFT_AdfsFarmNode/en-US/about_AdfsFarmNode.help.txt
@@ -47,11 +47,6 @@
     Write - String
     Specifies the SQL Server database that will store the AD FS configuration settings. If not specified, AD FS uses Windows Internal Database to store configuration settings.
 
-.PARAMETER Ensure
-    Write - String
-    Allowed values: Present, Absent
-    Specifies whether the ADFS Farm Node should be present or absent. Default value is 'Present'.
-
 .EXAMPLE 1
 
 This configuration will add the computer as a node in an existing Active Directory Federation Services (AD FS)


### PR DESCRIPTION
#### Pull Request (PR) description

This PR removes the `Ensure` parameter from the `AdfsFarmNode` resource as the `Remove-AdfsFarmNode` cmdlet that it uses is deprecated.

#### This Pull Request (PR) fixes the following issues

- Fixes #36 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in resource directory README.md.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-guardian/adfsdsc/37)
<!-- Reviewable:end -->
