### PR TITLE
AdfsDsc: Fix Sampler breaking change with GitHubTasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- AdfsDsc
+  - Fixed Sampler breaking change with GitHubTasks.
 - AdfsProperties
   - Fixed issues with unavailable properties on Windows Server 2016
   ([issue #51](https://github.com/X-Guardian/AdfsDsc/issues/51)).
+
 
 ## [1.1.0] - 2020-12-22
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -13,6 +13,7 @@
     Plaster                     = 'latest'
     ModuleBuilder               = '1.0.0'
     ChangelogManagement         = 'latest'
+    'Sampler.GitHubTasks'       = 'latest'
     Sampler                     = 'latest'
     MarkdownLinkCheck           = 'latest'
     'DscResource.Test'          = 'latest'

--- a/build.yaml
+++ b/build.yaml
@@ -78,6 +78,8 @@ Resolve-Dependency: #Parameters for Resolve-Dependency
 ModuleBuildTasks:
   Sampler:
     - '*.build.Sampler.ib.tasks' # this means: import (dot source) all aliases ending with .ib.tasks exported by sampler module
+  Sampler.GitHubTasks:
+    - '*.ib.tasks'
 
 # Invoke-Build Header to be used to 'decorate' the terminal output of the tasks.
 TaskHeader: |


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the Sampler module breaking change issue where the GitHub tasks including `Publish_release_to_GitHub` have been moved to an external module `Sampler.GitHubTasks` in PR https://github.com/gaelcolas/Sampler/pull/240.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/x-guardian/adfsdsc/53)
<!-- Reviewable:end -->
